### PR TITLE
Allow redisClient injection as well - Issue #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ const redis = require('redis');
 function PettyCache(options) {
     const intervals = {};
     let redisClient;
+
     if (options instanceof redis.RedisClient) {
-      redisClient = options;
+        redisClient = options;
     } else {
-      redisClient = redis.createClient(options);
+        redisClient = redis.createClient(options);
     }
 
     redisClient.on('error', err => console.warn(`Warning: Redis reported a client error: ${err}`));

--- a/index.js
+++ b/index.js
@@ -3,9 +3,14 @@ const lock = require('lock').Lock();
 const memoryCache = require('memory-cache');
 const redis = require('redis');
 
-function PettyCache(port, host, options) {
+function PettyCache(options) {
     const intervals = {};
-    const redisClient = redis.createClient(port || 6379, host || '127.0.0.1', options);
+    let redisClient;
+    if (options instanceof redis.RedisClient) {
+      redisClient = options;
+    } else {
+      redisClient = redis.createClient(options);
+    }
 
     redisClient.on('error', err => console.warn(`Warning: Redis reported a client error: ${err}`));
 

--- a/test/index.js
+++ b/test/index.js
@@ -217,27 +217,6 @@ describe('PettyCache.bulkFetch', function() {
             done();
         });
     });
-
-    it.skip('PettyCache.bulkFetch should return error from Redis', function(done) {
-        this.timeout(20000);
-
-        var key = Math.random().toString();
-
-        redisClient.debug('SEGFAULT', function() {
-            pettyCache.bulkFetch([key], function(keys, callback) {
-                assert.fail('func should not have been called');
-                callback();
-            }, function(err) {
-                assert(err);
-
-                // Give Redis a bit to recover from SEGFAULT
-                setTimeout(function() {
-                    redisClient = redis.createClient();
-                    redisClient.ping(done);
-                }, 10000);
-            });
-        });
-    });
 });
 
 describe('PettyCache.bulkGet', function() {
@@ -405,24 +384,6 @@ describe('PettyCache.bulkGet', function() {
             assert.ifError(err);
             assert.deepEqual(values, {});
             done();
-        });
-    });
-
-    it.skip('PettyCache.bulkGet should return error from Redis', function(done) {
-        this.timeout(20000);
-
-        var key = Math.random().toString();
-
-        redisClient.debug('SEGFAULT', function() {
-            pettyCache.bulkGet([key], function(err) {
-                assert(err);
-
-                // Give Redis a bit to recover from SEGFAULT
-                setTimeout(function() {
-                    redisClient = redis.createClient();
-                    redisClient.ping(done);
-                }, 10000);
-            });
         });
     });
 });
@@ -656,24 +617,6 @@ describe('PettyCache.del', function() {
             });
         });
     });
-
-    it.skip('PettyCache.del should return error from Redis', function(done) {
-        this.timeout(20000);
-
-        var key = Math.random().toString();
-
-        redisClient.debug('SEGFAULT', function() {
-            pettyCache.del(key, function(err) {
-                assert(err);
-
-                // Give Redis a bit to recover from SEGFAULT
-                setTimeout(function() {
-                    redisClient = redis.createClient();
-                    redisClient.ping(done);
-                }, 10000);
-            });
-        });
-    });
 });
 
 describe('PettyCache.fetch', function() {
@@ -862,27 +805,6 @@ describe('PettyCache.fetch', function() {
             done();
         });
     });
-
-    it.skip('PettyCache.fetch should return error from Redis', function(done) {
-        this.timeout(20000);
-
-        var key = Math.random().toString();
-
-        redisClient.debug('SEGFAULT', function() {
-            pettyCache.fetch(key, function(callback) {
-                assert.fail('func should not have been called');
-                callback();
-            }, function(err) {
-                assert(err);
-
-                // Give Redis a bit to recover from SEGFAULT
-                setTimeout(function() {
-                    redisClient = redis.createClient();
-                    redisClient.ping(done);
-                }, 10000);
-            });
-        });
-    });
 });
 
 describe('PettyCache.fetchAndRefresh', function() {
@@ -1042,24 +964,6 @@ describe('PettyCache.get', function() {
             });
         });
     });
-
-    it.skip('PettyCache.get should return error from Redis', function(done) {
-        this.timeout(20000);
-
-        var key = Math.random().toString();
-
-        redisClient.debug('SEGFAULT', function() {
-            pettyCache.get(key, function(err) {
-                assert(err);
-
-                // Give Redis a bit to recover from SEGFAULT
-                setTimeout(function() {
-                    redisClient = redis.createClient();
-                    redisClient.ping(done);
-                }, 10000);
-            });
-        });
-    });
 });
 
 describe('PettyCache.mutex', function() {
@@ -1191,24 +1095,6 @@ describe('PettyCache.patch', function() {
                 assert(!err, 'Error: ' + err);
                 assert.deepEqual(data, { a: 1, b: 5, c: 6 });
                 done();
-            });
-        });
-    });
-
-    it.skip('PettyCache.patch should return error from Redis', function(done) {
-        this.timeout(20000);
-
-        var key = Math.random().toString();
-
-        redisClient.debug('SEGFAULT', function() {
-            pettyCache.patch(key, { b: 6, c: 7 }, function(err) {
-                assert(err);
-
-                // Give Redis a bit to recover from SEGFAULT
-                setTimeout(function() {
-                    redisClient = redis.createClient();
-                    redisClient.ping(done);
-                }, 10000);
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,8 @@ const redis = require('redis');
 
 const PettyCache = require('../index.js');
 
-const pettyCache = new PettyCache();
-var redisClient = redis.createClient();
+const redisClient = redis.createClient();
+const pettyCache = new PettyCache(redisClient);
 
 describe('memory-cache', function() {
     it('memoryCache.put(key, \'\')', function(done) {
@@ -956,7 +956,7 @@ describe('PettyCache.fetchAndRefresh', function() {
 
         pettyCache.fetchAndRefresh(key, func, { ttl: 6000 });
 
-        const pettyCache2 = new PettyCache();
+        const pettyCache2 = new PettyCache(redisClient);
 
         pettyCache2.fetchAndRefresh(key, func, { ttl: 6000 }, function(err, data) {
             assert.equal(data, 1);


### PR DESCRIPTION
This package works great for locking and in-memory cache. I needed more API/Commands of redisClient, so instead of creating new redisClient, I have modified it to allow redisClient injection in this Class.

Raising this PR if someone else needs it as well (as mentioned in issue #9 ).