### PR TITLE
Add promise support to fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added the ability for the `pettyCache.fetch` function to support callbacks and promises.
 
 ## [3.7.0] - 2026-03-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.8.0] - 2026-08-03
 ### Changed
 - Added the ability for the `pettyCache.fetch` function to support callbacks and promises.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.8.0] - 2026-08-03
 ### Changed
 - Added the ability for the `pettyCache.fetch` function to support callbacks and promises.
+- Modernized the internals of `fetch`, `get`, `bulkGet`, and `bulkFetch` to async/await.
+### Fixed
+- A cache-miss function passed to `fetch` that throws synchronously no longer leaves the in-process locks for that key held forever.
 
 ## [3.7.0] - 2026-03-12
 ### Changed

--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ pettyCache.del('key', function(err) {
 await pettyCache.del('key');
 ```
 
-### pettyCache.fetch(key, cacheMissFunction, [options,] callback)
+### pettyCache.fetch(key, cacheMissFunction, [options, [callback]])
 
-Attempts to retrieve the value from cache at the specified key. If it doesn't exist, it executes the specified cacheMissFunction that takes two parameters: an error and a value. `cacheMissFunction` should retrieve the expected value for the key from another source and pass it to the given callback. Either way, the resulting error or value is passed to `callback`.
+Attempts to retrieve the value from cache at the specified key. If it doesn't exist, it executes the specified cacheMissFunction that takes two parameters: an error and a value. `cacheMissFunction` should retrieve the expected value for the key from another source and pass it to the given callback. Either way, the resulting error or value is passed to `callback`. Supports both callbacks and promises.
 
 **Example**
 
@@ -188,6 +188,13 @@ pettyCache.fetch('key', async () => {
 }, function(err, value) {
     // This callback is called once petty-cache has loaded data from cache or executed the specified cache miss function
     console.log(value);
+});
+```
+
+```javascript
+const value = await pettyCache.fetch('key', async () => {
+    // This function is called on a cache miss
+    return await fs.readFile('file.txt');
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -24,30 +24,32 @@ function PettyCache() {
     /**
      * Fetches multiple keys from Redis.
      * @param {string[]} keys
-     * @param {Function} callback - callback(err, values) where values maps each key to {exists, value}.
+     * @returns {Promise<Object>} Resolves with an object mapping each key to {exists, value}.
      */
-    function bulkGetFromRedis(keys, callback) {
-        // Try to get values from Redis
-        redisClient.mget(keys, (err, data) => {
-            if (err) {
-                return callback(err);
-            }
-
-            const values = {};
-
-            for (let i = 0; i < keys.length; i++) {
-                const key = keys[i];
-                const value = data[i];
-
-                if (value === null) {
-                    values[key] = { exists: false };
-                    continue;
+    function bulkGetFromRedis(keys) {
+        return new Promise((resolve, reject) => {
+            // Try to get values from Redis
+            redisClient.mget(keys, (err, data) => {
+                if (err) {
+                    return reject(err);
                 }
 
-                values[key] = { exists: true, value: PettyCache.parse(value) };
-            }
+                const values = {};
 
-            callback(null, values);
+                for (let i = 0; i < keys.length; i++) {
+                    const key = keys[i];
+                    const value = data[i];
+
+                    if (value === null) {
+                        values[key] = { exists: false };
+                        continue;
+                    }
+
+                    values[key] = { exists: true, value: PettyCache.parse(value) };
+                }
+
+                resolve(values);
+            });
         });
     }
 
@@ -77,21 +79,23 @@ function PettyCache() {
     /**
      * Fetches a single key from Redis.
      * @param {string} key
-     * @param {Function} callback - callback(err, {exists, value}).
+     * @returns {Promise<{exists: boolean, value: *}>}
      */
-    function getFromRedis(key, callback) {
-        // Try to get value from Redis
-        redisClient.get(key, (err, data) => {
-            if (err) {
-                return callback(err);
-            }
+    function getFromRedis(key) {
+        return new Promise((resolve, reject) => {
+            // Try to get value from Redis
+            redisClient.get(key, (err, data) => {
+                if (err) {
+                    return reject(err);
+                }
 
-            // Return if the key wasn't found in Redis
-            if (data === null) {
-                return callback(null, { exists: false });
-            }
+                // Return if the key wasn't found in Redis
+                if (data === null) {
+                    return resolve({ exists: false });
+                }
 
-            callback(null, { exists: true, value: PettyCache.parse(data) });
+                resolve({ exists: true, value: PettyCache.parse(data) });
+            });
         });
     }
 
@@ -142,74 +146,68 @@ function PettyCache() {
             options = {};
         }
 
-        const executor = () => {
-            return new Promise((resolve, reject) => {
-                // If there aren't any keys, return
-                if (!keys.length) {
-                    return resolve({});
+        const executor = async () => {
+            // If there aren't any keys, return
+            if (!keys.length) {
+                return {};
+            }
+
+            const _keys = Array.from(new Set(keys));
+            const values = {};
+
+            // Try to get values from memory cache
+            for (let i = _keys.length - 1; i >= 0; i--) {
+                const key = _keys[i];
+                const result = getFromMemoryCache(key);
+
+                if (result.exists) {
+                    values[key] = result.value;
+                    _keys.splice(i, 1);
                 }
+            }
 
-                const _keys = Array.from(new Set(keys));
-                const values = {};
+            // If there aren't any keys left, return
+            if (!_keys.length) {
+                return values;
+            }
 
-                // Try to get values from memory cache
-                for (let i = _keys.length - 1; i >= 0; i--) {
-                    const key = _keys[i];
-                    const result = getFromMemoryCache(key);
+            // Try to get values from Redis
+            const results = await bulkGetFromRedis(_keys);
 
-                    if (result.exists) {
-                        values[key] = result.value;
-                        _keys.splice(i, 1);
-                    }
+            for (let i = _keys.length - 1; i >= 0; i--) {
+                const key = _keys[i];
+                const result = results[key];
+
+                if (result.exists) {
+                    _keys.splice(i, 1);
+                    values[key] = result.value;
+
+                    // Store value in memory cache with a short expiration
+                    memoryCache.put(key, result.value, random(2000, 5000));
                 }
+            }
 
-                // If there aren't any keys left, return
-                if (!_keys.length) {
-                    return resolve(values);
-                }
+            // If there aren't any keys left, return
+            if (!_keys.length) {
+                return values;
+            }
 
-                // Try to get values from Redis
-                bulkGetFromRedis(_keys, (err, results) => {
+            // Execute the specified function for remaining keys
+            const data = await new Promise((resolve, reject) => {
+                func(_keys, (err, data) => {
                     if (err) {
                         return reject(err);
                     }
 
-                    for (let i = _keys.length - 1; i >= 0; i--) {
-                        const key = _keys[i];
-                        const result = results[key];
-
-                        if (result.exists) {
-                            _keys.splice(i, 1);
-                            values[key] = result.value;
-
-                            // Store value in memory cache with a short expiration
-                            memoryCache.put(key, result.value, random(2000, 5000));
-                        }
-                    }
-
-                    // If there aren't any keys left, return
-                    if (!_keys.length) {
-                        return resolve(values);
-                    }
-
-                    // Execute the specified function for remaining keys
-                    func(_keys, (err, data) => {
-                        if (err) {
-                            return reject(err);
-                        }
-
-                        Object.keys(data).forEach(key => values[key] = data[key]);
-
-                        this.bulkSet(data, options, err => {
-                            if (err) {
-                                return reject(err);
-                            }
-
-                            resolve(values);
-                        });
-                    });
+                    resolve(data);
                 });
             });
+
+            Object.keys(data).forEach(key => values[key] = data[key]);
+
+            await this.bulkSet(data, options);
+
+            return values;
         };
 
         if (callback) {
@@ -226,56 +224,50 @@ function PettyCache() {
      * @returns {Promise|undefined} Resolves with an object mapping each key to its value, or null if not found.
      */
     this.bulkGet = (keys, callback) => {
-        const executor = () => {
-            return new Promise((resolve, reject) => {
-                // If there aren't any keys, return
-                if (!keys.length) {
-                    return resolve({});
+        const executor = async () => {
+            // If there aren't any keys, return
+            if (!keys.length) {
+                return {};
+            }
+
+            const _keys = Array.from(new Set(keys));
+            const values = {};
+
+            // Try to get values from memory cache
+            for (let i = _keys.length - 1; i >= 0; i--) {
+                const key = _keys[i];
+                const result = getFromMemoryCache(key);
+
+                if (result.exists) {
+                    values[key] = result.value;
+                    _keys.splice(i, 1);
+                }
+            }
+
+            // If there aren't any keys left, return
+            if (!_keys.length) {
+                return values;
+            }
+
+            // Try to get values from Redis
+            const results = await bulkGetFromRedis(_keys);
+
+            for (let i = 0; i < _keys.length; i++) {
+                const key = _keys[i];
+                const result = results[key];
+
+                if (!result.exists) {
+                    values[key] = null;
+                    continue;
                 }
 
-                const _keys = Array.from(new Set(keys));
-                const values = {};
+                values[key] = result.value;
 
-                // Try to get values from memory cache
-                for (let i = _keys.length - 1; i >= 0; i--) {
-                    const key = _keys[i];
-                    const result = getFromMemoryCache(key);
+                // Store value in memory cache with a short expiration
+                memoryCache.put(key, result.value, random(2000, 5000));
+            }
 
-                    if (result.exists) {
-                        values[key] = result.value;
-                        _keys.splice(i, 1);
-                    }
-                }
-
-                // If there aren't any keys left, return
-                if (!_keys.length) {
-                    return resolve(values);
-                }
-
-                // Try to get values from Redis
-                bulkGetFromRedis(_keys, (err, results) => {
-                    if (err) {
-                        return reject(err);
-                    }
-
-                    for (let i = 0; i < _keys.length; i++) {
-                        const key = _keys[i];
-                        const result = results[key];
-
-                        if (!result.exists) {
-                            values[key] = null;
-                            continue;
-                        }
-
-                        values[key] = result.value;
-
-                        // Store value in memory cache with a short expiration
-                        memoryCache.put(key, result.value, random(2000, 5000));
-                    }
-
-                    resolve(values);
-                });
-            });
+            return values;
         };
 
         if (callback) {
@@ -378,107 +370,85 @@ function PettyCache() {
             options = {};
         }
 
-        const _this = this;
+        const executor = async () => {
+            // Try to get value from memory cache
+            let result = getFromMemoryCache(key);
 
-        const executor = () => {
-            return new Promise((resolve, reject) => {
+            // Return value from memory cache if it exists
+            if (result.exists) {
+                return result.value;
+            }
+
+            // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
+            const releaseMemoryCacheLock = await acquireLock(`fetch-memory-cache-lock-${key}`);
+
+            try {
                 // Try to get value from memory cache
-                let result = getFromMemoryCache(key);
+                result = getFromMemoryCache(key);
 
                 // Return value from memory cache if it exists
                 if (result.exists) {
-                    return resolve(result.value);
+                    return result.value;
+                }
+
+                // Try to get value from Redis
+                result = await getFromRedis(key);
+
+                // Return value from Redis if it exists
+                if (result.exists) {
+                    memoryCache.put(key, result.value, random(2000, 5000));
+                    return result.value;
                 }
 
                 // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
-                lock(`fetch-memory-cache-lock-${key}`, (releaseMemoryCacheLock) => {
-                    async.reflect((callback) => {
-                        // Try to get value from memory cache
-                        result = getFromMemoryCache(key);
+                const releaseRedisLock = await acquireLock(`fetch-redis-lock-${key}`);
 
-                        // Return value from memory cache if it exists
-                        if (result.exists) {
-                            return callback(null, result.value);
-                        }
+                try {
+                    // Try to get value from memory cache
+                    result = getFromMemoryCache(key);
 
-                        // Try to get value from Redis
-                        getFromRedis(key, (err, result) => {
-                            if (err) {
-                                return callback(err);
-                            }
+                    // Return value from memory cache if it exists
+                    if (result.exists) {
+                        return result.value;
+                    }
 
-                            // Return value from Redis if it exists
-                            if (result.exists) {
-                                memoryCache.put(key, result.value, random(2000, 5000));
-                                return callback(null, result.value);
-                            }
+                    // Try to get value from Redis
+                    result = await getFromRedis(key);
 
-                            // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
-                            lock(`fetch-redis-lock-${key}`, (releaseRedisLock) => {
-                                async.reflect((callback) => {
-                                    // Try to get value from memory cache
-                                    result = getFromMemoryCache(key);
+                    // Return value from Redis if it exists
+                    if (result.exists) {
+                        memoryCache.put(key, result.value, random(2000, 5000));
+                        return result.value;
+                    }
 
-                                    // Return value from memory cache if it exists
-                                    if (result.exists) {
-                                        return callback(null, result.value);
-                                    }
+                    // Execute the specified function and place the results in cache before returning the data
+                    let data;
 
-                                    // Try to get value from Redis
-                                    getFromRedis(key, async (err, result) => {
-                                        if (err) {
-                                            return callback(err);
-                                        }
+                    if (func.length === 0) {
+                        // If the function doesn't have any arguments, there wasn't a callback provided
+                        data = await func();
+                    } else {
+                        // If the function has arguments, there was a callback provided
+                        data = await new Promise((resolve, reject) => {
+                            func((err, data) => {
+                                if (err) {
+                                    return reject(err);
+                                }
 
-                                        // Return value from Redis if it exists
-                                        if (result.exists) {
-                                            memoryCache.put(key, result.value, random(2000, 5000));
-                                            return callback(null, result.value);
-                                        }
-
-                                        // Execute the specified function and place the results in cache before returning the data
-                                        if (func.length === 0) {
-                                            // If the function doesn't have any arguments, there wasn't a callback provided
-                                            try {
-                                                const data = await func();
-
-                                                _this.set(key, data, options, (err) => {
-                                                    callback(err, data);
-                                                });
-                                            } catch(err) {
-                                                callback(err);
-                                            }
-                                        } else {
-                                            // If the function has arguments, there was a callback provided
-                                            func((err, data) => {
-                                                if (err) {
-                                                    return callback(err);
-                                                }
-
-                                                _this.set(key, data, options, (err) => {
-                                                    callback(err, data);
-                                                });
-                                            });
-                                        }
-                                    });
-                                })(releaseRedisLock((err, result) => {
-                                    if (result.error) {
-                                        return callback(result.error);
-                                    }
-
-                                    callback(null, result.value);
-                                }));
+                                resolve(data);
                             });
                         });
-                    })(releaseMemoryCacheLock((err, result) => {
-                        if (result.error) {
-                            return reject(result.error);
-                        }
+                    }
 
-                        resolve(result.value);
-                    }));
-                });
-            });
+                    await this.set(key, data, options);
+
+                    return data;
+                } finally {
+                    releaseRedisLock();
+                }
+            } finally {
+                releaseMemoryCacheLock();
+            }
         };
 
         if (callback) {
@@ -543,48 +513,42 @@ function PettyCache() {
      * @returns {Promise|undefined} Resolves with the cached value, or null if not found.
      */
     this.get = (key, callback) => {
-        const executor = () => {
-            return new Promise((resolve, reject) => {
+        const executor = async () => {
+            // Try to get value from memory cache
+            let result = getFromMemoryCache(key);
+
+            // Return value from memory cache if it exists
+            if (result.exists) {
+                return result.value;
+            }
+
+            // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
+            const releaseMemoryCacheLock = await acquireLock(`get-memory-cache-lock-${key}`);
+
+            try {
                 // Try to get value from memory cache
-                let result = getFromMemoryCache(key);
+                result = getFromMemoryCache(key);
 
                 // Return value from memory cache if it exists
                 if (result.exists) {
-                    return resolve(result.value);
+                    return result.value;
                 }
 
-                // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
-                lock(`get-memory-cache-lock-${key}`, (releaseMemoryCacheLock) => {
-                    async.reflect((callback) => {
-                        // Try to get value from memory cache
-                        result = getFromMemoryCache(key);
+                // Try to get value from Redis
+                result = await getFromRedis(key);
 
-                        // Return value from memory cache if it exists
-                        if (result.exists) {
-                            return callback(null, result.value);
-                        }
+                // Return null if the key wasn't found in Redis
+                if (!result.exists) {
+                    return null;
+                }
 
-                        getFromRedis(key, (err, result) => {
-                            if (err) {
-                                return callback(err);
-                            }
+                // Store value in memory cache with a short expiration
+                memoryCache.put(key, result.value, random(2000, 5000));
 
-                            if (!result.exists) {
-                                return callback(null, null);
-                            }
-
-                            memoryCache.put(key, result.value, random(2000, 5000));
-                            callback(null, result.value);
-                        });
-                    })(releaseMemoryCacheLock((err, result) => {
-                        if (result.error) {
-                            return reject(result.error);
-                        }
-
-                        resolve(result.value);
-                    }));
-                });
-            });
+                return result.value;
+            } finally {
+                releaseMemoryCacheLock();
+            }
         };
 
         if (callback) {
@@ -1100,6 +1064,17 @@ function PettyCache() {
     for (const method in this.semaphore) {
         this.semaphore[method] = this.semaphore[method].bind(this);
     }
+}
+
+/**
+ * Acquires the in-process lock for the given key and resolves once it's held.
+ * @param {string} key
+ * @returns {Promise<Function>} Resolves with a function that releases the lock.
+ */
+function acquireLock(key) {
+    return new Promise(resolve => {
+        lock(key, release => resolve(release()));
+    });
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -363,12 +363,14 @@ function PettyCache() {
 
     /**
      * Returns data from cache if available; otherwise executes func, stores the result, and returns it.
-     * Uses double-checked locking to prevent cache stampedes. Supports async and callback func signatures.
+     * Uses double-checked locking to prevent cache stampedes. Supports async and callback func signatures,
+     * and both callback and promise styles.
      * @param {string} key - The cache key.
      * @param {Function} func - Called on cache miss. Use func(callback) for callbacks or async func() for promises.
      * @param {Object} [options] - Optional settings.
      * @param {number|Object} [options.ttl] - TTL in ms, or object with min/max properties.
-     * @param {Function} [callback] - Optional callback(err, value). Defaults to a noop.
+     * @param {Function} [callback] - Optional callback(err, value). If omitted, returns a Promise.
+     * @returns {Promise|undefined} Resolves with the cached or newly fetched value.
      */
     this.fetch = (key, func, options = {}, callback) => {
         if (typeof options === 'function') {
@@ -376,107 +378,114 @@ function PettyCache() {
             options = {};
         }
 
-        // Default callback is a noop
-        callback = callback || (() => {});
-
-        // Try to get value from memory cache
-        let result = getFromMemoryCache(key);
-
-        // Return value from memory cache if it exists
-        if (result.exists) {
-            return callback(null, result.value);
-        }
-
         const _this = this;
 
-        // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
-        lock(`fetch-memory-cache-lock-${key}`, (releaseMemoryCacheLock) => {
-            async.reflect((callback) => {
+        const executor = () => {
+            return new Promise((resolve, reject) => {
                 // Try to get value from memory cache
-                result = getFromMemoryCache(key);
+                let result = getFromMemoryCache(key);
 
                 // Return value from memory cache if it exists
                 if (result.exists) {
-                    return callback(null, result.value);
+                    return resolve(result.value);
                 }
 
-                // Try to get value from Redis
-                getFromRedis(key, (err, result) => {
-                    if (err) {
-                        return callback(err);
-                    }
+                // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
+                lock(`fetch-memory-cache-lock-${key}`, (releaseMemoryCacheLock) => {
+                    async.reflect((callback) => {
+                        // Try to get value from memory cache
+                        result = getFromMemoryCache(key);
 
-                    // Return value from Redis if it exists
-                    if (result.exists) {
-                        memoryCache.put(key, result.value, random(2000, 5000));
-                        return callback(null, result.value);
-                    }
+                        // Return value from memory cache if it exists
+                        if (result.exists) {
+                            return callback(null, result.value);
+                        }
 
-                    // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
-                    lock(`fetch-redis-lock-${key}`, (releaseRedisLock) => {
-                        async.reflect((callback) => {
-                            // Try to get value from memory cache
-                            result = getFromMemoryCache(key);
+                        // Try to get value from Redis
+                        getFromRedis(key, (err, result) => {
+                            if (err) {
+                                return callback(err);
+                            }
 
-                            // Return value from memory cache if it exists
+                            // Return value from Redis if it exists
                             if (result.exists) {
+                                memoryCache.put(key, result.value, random(2000, 5000));
                                 return callback(null, result.value);
                             }
 
-                            // Try to get value from Redis
-                            getFromRedis(key, async (err, result) => {
-                                if (err) {
-                                    return callback(err);
-                                }
+                            // Double-checked locking: http://en.wikipedia.org/wiki/Double-checked_locking
+                            lock(`fetch-redis-lock-${key}`, (releaseRedisLock) => {
+                                async.reflect((callback) => {
+                                    // Try to get value from memory cache
+                                    result = getFromMemoryCache(key);
 
-                                // Return value from Redis if it exists
-                                if (result.exists) {
-                                    memoryCache.put(key, result.value, random(2000, 5000));
-                                    return callback(null, result.value);
-                                }
-
-                                // Execute the specified function and place the results in cache before returning the data
-                                if (func.length === 0) {
-                                    // If the function doesn't have any arguments, there wasn't a callback provided
-                                    try {
-                                        const data = await func();
-
-                                        _this.set(key, data, options, (err) => {
-                                            callback(err, data);
-                                        });
-                                    } catch(err) {
-                                        callback(err);
+                                    // Return value from memory cache if it exists
+                                    if (result.exists) {
+                                        return callback(null, result.value);
                                     }
-                                } else {
-                                    // If the function has arguments, there was a callback provided
-                                    func((err, data) => {
+
+                                    // Try to get value from Redis
+                                    getFromRedis(key, async (err, result) => {
                                         if (err) {
                                             return callback(err);
                                         }
 
-                                        _this.set(key, data, options, (err) => {
-                                            callback(err, data);
-                                        });
+                                        // Return value from Redis if it exists
+                                        if (result.exists) {
+                                            memoryCache.put(key, result.value, random(2000, 5000));
+                                            return callback(null, result.value);
+                                        }
+
+                                        // Execute the specified function and place the results in cache before returning the data
+                                        if (func.length === 0) {
+                                            // If the function doesn't have any arguments, there wasn't a callback provided
+                                            try {
+                                                const data = await func();
+
+                                                _this.set(key, data, options, (err) => {
+                                                    callback(err, data);
+                                                });
+                                            } catch(err) {
+                                                callback(err);
+                                            }
+                                        } else {
+                                            // If the function has arguments, there was a callback provided
+                                            func((err, data) => {
+                                                if (err) {
+                                                    return callback(err);
+                                                }
+
+                                                _this.set(key, data, options, (err) => {
+                                                    callback(err, data);
+                                                });
+                                            });
+                                        }
                                     });
-                                }
+                                })(releaseRedisLock((err, result) => {
+                                    if (result.error) {
+                                        return callback(result.error);
+                                    }
+
+                                    callback(null, result.value);
+                                }));
                             });
-                        })(releaseRedisLock((err, result) => {
-                            if (result.error) {
-                                return callback(result.error);
-                            }
+                        });
+                    })(releaseMemoryCacheLock((err, result) => {
+                        if (result.error) {
+                            return reject(result.error);
+                        }
 
-                            callback(null, result.value);
-                        }));
-                    });
+                        resolve(result.value);
+                    }));
                 });
-            })(releaseMemoryCacheLock((err, result) => {
-                if (result.error) {
-                    return callback(result.error);
-                }
+            });
+        };
 
-                callback(null, result.value);
-            }));
-        });
+        if (callback) {
+            executor().then(result => callback(null, result)).catch(callback);
+        } else {
+            return executor();
+        }
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
         "test": "node --test --test-force-exit --test-reporter=spec",
         "test:only": "node --test --test-force-exit --test-only --test-reporter=spec"
     },
-    "version": "3.7.0"
+    "version": "3.8.0"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1082,6 +1082,60 @@ test('petty-cache', { concurrency: true }, async (t) => {
                 });
             });
         });
+
+        t.test('PettyCache.fetch should return value (promises)', async () => {
+            const key = Math.random().toString();
+
+            const data = await pettyCache.fetch(key, (callback) => {
+                return callback(null, { foo: 'bar' });
+            });
+
+            assert.strictEqual(data.foo, 'bar');
+
+            const cached = await pettyCache.fetch(key, () => {
+                throw 'This function should not be called';
+            });
+
+            assert.strictEqual(cached.foo, 'bar');
+        });
+
+        t.test('PettyCache.fetch should reject if func returns error (promises)', async () => {
+            await assert.rejects(
+                pettyCache.fetch(Math.random().toString(), (callback) => {
+                    callback(new Error('PettyCache.fetch should reject if func returns error'));
+                }),
+                { message: 'PettyCache.fetch should reject if func returns error' }
+            );
+        });
+
+        t.test('PettyCache.fetch should support async func (promises)', async () => {
+            const key = Math.random().toString();
+
+            const data = await pettyCache.fetch(key, async () => {
+                return { foo: 'bar' };
+            });
+
+            assert.strictEqual(data.foo, 'bar');
+        });
+
+        t.test('PettyCache.fetch should reject if async func throws error (promises)', async () => {
+            await assert.rejects(
+                pettyCache.fetch(Math.random().toString(), async () => {
+                    throw new Error('PettyCache.fetch should reject if async func throws error');
+                }),
+                { message: 'PettyCache.fetch should reject if async func throws error' }
+            );
+        });
+
+        t.test('PettyCache.fetch should return value with options (promises)', async () => {
+            const key = Math.random().toString();
+
+            const data = await pettyCache.fetch(key, (callback) => {
+                return callback(null, 'value');
+            }, { ttl: 6000 });
+
+            assert.strictEqual(data, 'value');
+        });
     });
 
     t.test('PettyCache.fetchAndRefresh', { concurrency: true }, async (t) => {


### PR DESCRIPTION
Converts `pettyCache.fetch` to the executor pattern so it supports both callback and promise styles, matching every other method in the API (`get`/`set`/`patch` in 3.6.0, `bulkGet`/`bulkSet`/`bulkFetch` in 3.7.0), then modernizes the internals to async/await. Releases as **3.8.0**. `fetchAndRefresh` is now the only remaining callback-only method.

## Changes

- `fetch` supports promise style: omit the callback and it returns a Promise. Removed the old "default callback is a noop" fallback (no caller in the fleet invokes `fetch` without a callback).
- `getFromRedis` and `bulkGetFromRedis` now return promises; a new `acquireLock` helper promisifies the in-process `lock` package.
- The `fetch`, `get`, `bulkGet`, and `bulkFetch` executors are rewritten as linear async functions, removing the `async.reflect` release plumbing and ~10 levels of nesting. Double-checked-locking behavior is preserved exactly: same re-check ladder (memory → lock → memory → Redis → lock → memory → Redis → func → set), locks released via `try/finally` before the promise settles, waiter coalescing unchanged (the `lock` package schedules waiters on `setImmediate` after release).
- Behavior fix: a callback-style cache-miss function that throws synchronously now rejects cleanly; previously it produced an unhandled rejection with both in-process locks held forever.
- Behavior note: on a memory-cache hit the callback is now always deferred through the microtask queue instead of invoked synchronously, matching what `get`/`set` adopted in 3.6.0.
- Five new `(promises)` tests for `fetch`: resolve on miss and on cache hit, reject on func error, async func support, reject on async func throw, and the `{ ttl }` options form.
- README `fetch` section updated; CHANGELOG entries under 3.8.0; `package.json` bumped to 3.8.0.

## Testing

- Full suite: 186 tests pass, 0 fail (against local Redis), including the double-checked-lock error-injection tests and the concurrent-fetch coalescing test
- ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)